### PR TITLE
Fix docker-compose deployment issues and add troubleshooting guides

### DIFF
--- a/docker/ACCESS_UI.md
+++ b/docker/ACCESS_UI.md
@@ -12,6 +12,77 @@ After successful deployment, access your application:
 - Health check: `http://YOUR_SERVER_IP:8000/health`
 - API docs: `http://YOUR_SERVER_IP:8000/docs`
 
+## Finding Your Server IP
+
+### From the Server:
+```bash
+# Public IP
+curl ifconfig.me
+
+# OR all IPs
+hostname -I
+
+# OR from Oracle Cloud metadata
+curl -s http://169.254.169.254/opc/v1/instance/ | grep -i publicIp
+```
+
+### From Oracle Cloud Console:
+1. Go to **Compute** → **Instances**
+2. Click on your instance
+3. Find **Public IP address** in the details
+
+## IP Address Changes
+
+### What Happens if IP Changes?
+
+✅ **API Calls Continue Working** - The frontend uses relative URLs (`/api/v1`), so API calls will work regardless of IP changes.
+
+❌ **You Need to Update Browser URL** - You'll need to access the app using the new IP address.
+
+### Solutions for IP Stability:
+
+#### 1. **Static IP (Recommended for Production)**
+
+Reserve a static public IP in Oracle Cloud:
+
+1. Go to **Networking** → **IP Management** → **Reserved Public IPs**
+2. Click **Create Reserved Public IP**
+3. Choose **Regional** scope
+4. Assign it to your compute instance
+5. **Result:** IP never changes, even after restart
+
+#### 2. **Use a Domain Name**
+
+Point a domain to your server:
+
+1. Buy/use a domain (e.g., from Namecheap, Cloudflare, etc.)
+2. Create an **A Record** pointing to your server IP:
+   ```
+   yourdomain.com → YOUR_SERVER_IP
+   ```
+3. Access via: `http://yourdomain.com:5173`
+4. **Note:** Update DNS A record if IP changes
+
+#### 3. **Dynamic DNS (Auto-Update)**
+
+If IP changes frequently, use Dynamic DNS:
+
+- Services: No-IP, DuckDNS, Cloudflare Dynamic DNS
+- Script runs on server to update DNS when IP changes
+- Always access via same domain name
+
+### Quick Fix: Find New IP
+
+If your IP changed, find the new one:
+
+```bash
+# On the server
+curl ifconfig.me
+
+# Then update your browser bookmark/URL to:
+# http://NEW_IP:5173
+```
+
 ## Verify Containers Are Running
 
 ```bash
@@ -24,16 +95,6 @@ docker logs tradeagent-api
 
 # Check if ports are listening
 sudo netstat -tlnp | grep -E '5173|8000'
-```
-
-## Find Your Server IP
-
-```bash
-# Public IP
-curl ifconfig.me
-
-# OR all IPs
-hostname -I
 ```
 
 ## Oracle Cloud Firewall Configuration

--- a/docker/FIX_CONTAINER_CONFIG_ERROR.md
+++ b/docker/FIX_CONTAINER_CONFIG_ERROR.md
@@ -1,0 +1,49 @@
+# Fixing ContainerConfig KeyError
+
+If you see this error:
+```
+KeyError: 'ContainerConfig'
+```
+
+This is a known bug in Docker Compose v1.29.2 when recreating containers.
+
+## Quick Fix
+
+Run these commands on your Ubuntu server:
+
+```bash
+cd ~/modular_trade_agent/docker
+
+# Stop and remove all containers
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml down
+
+# Remove the problematic container/image (if needed)
+docker rm -f tradeagent-web 2>/dev/null || true
+docker rmi docker_web-frontend 2>/dev/null || true
+
+# Rebuild and start fresh
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+
+## Alternative: Force Remove Only Web Container
+
+If you want to keep the API container running:
+
+```bash
+# Force remove just the web container
+docker rm -f tradeagent-web
+
+# Then recreate it
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d web-frontend
+```
+
+## Root Cause
+
+The error occurs when Docker Compose tries to inspect an existing container's image metadata and encounters corrupted or missing data. Removing and recreating fixes it.
+
+## Prevention
+
+If this happens frequently, consider:
+1. Always use `docker-compose down` before major changes
+2. Rebuild images when configuration changes: `docker-compose up -d --build`
+3. Use named volumes to persist data (already configured)

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -25,15 +25,8 @@ services:
         max-file: "5"
         compress: "true"
 
-    # Production resource limits
-    deploy:
-      resources:
-        limits:
-          cpus: '1.0'
-          memory: 2G
-        reservations:
-          cpus: '0.5'
-          memory: 1G
+    # Note: Resource limits removed - deploy.resources is only for Docker Swarm mode
+    # For standalone Docker Compose, use docker stats or cgroup limits instead
 
   web-frontend:
     # Production: Use nginx with proper configuration
@@ -47,15 +40,8 @@ services:
         max-file: "3"
         compress: "true"
 
-    # Minimal resources for static file serving
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 512M
-        reservations:
-          cpus: '0.25'
-          memory: 256M
+    # Note: Resource limits removed - deploy.resources is only for Docker Swarm mode
+    # For standalone Docker Compose, use docker stats or cgroup limits instead
 
 # Production volumes (named volumes for better management)
 volumes:


### PR DESCRIPTION
- Fix docker-compose.prod.yml: Remove unsupported deploy.resources (Docker Swarm only)
  - Removes warnings about unsupported deploy sub-keys in standalone mode
  - Resource limits don't work in standalone docker-compose

- Add docker/FIX_CONTAINER_CONFIG_ERROR.md: Troubleshooting guide for ContainerConfig KeyError

- Update docker/ACCESS_UI.md: Add IP change handling, static IP guidance, and domain info

Fixes docker-compose deployment warnings and provides solutions for common issues.