### PR TITLE
Fix return percentage calculation in paper trading portfolio

### DIFF
--- a/tests/unit/server/routers/test_paper_trading.py
+++ b/tests/unit/server/routers/test_paper_trading.py
@@ -598,3 +598,785 @@ def test_get_paper_trading_portfolio_order_statistics(monkeypatch):
         assert result.order_statistics["completed_orders"] == 1
         assert result.order_statistics["pending_orders"] == 1
         assert result.order_statistics["reentry_orders"] == 1
+
+
+def test_get_paper_trading_portfolio_return_percentage_calculation(monkeypatch):
+    """Test that return_percentage is calculated correctly based on total_pnl"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    # Test case 1: Positive P&L
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 40000.0,
+        "realized_pnl": 5000.0,  # Realized profit
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 20,
+            "average_price": 2500.0,
+            "current_price": 2750.0,  # Unrealized profit: 20 * (2750 - 2500) = 5000
+        }
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+        mock_ticker_instance = MagicMock()
+        mock_ticker_instance.info = {"currentPrice": 2750.0}
+        mock_ticker_class.return_value = mock_ticker_instance
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Expected: total_pnl = realized_pnl (5000) + unrealized_pnl (5000) = 10000
+        # return_percentage = (10000 / 100000) * 100 = 10.0%
+        expected_total_pnl = 5000.0 + (20 * (2750.0 - 2500.0))  # 10000.0
+        expected_return_pct = (expected_total_pnl / 100000.0) * 100  # 10.0%
+
+        assert result.account.total_pnl == expected_total_pnl
+        assert result.account.return_percentage == pytest.approx(expected_return_pct, rel=1e-6)
+        assert result.account.return_percentage == 10.0
+
+
+def test_get_paper_trading_portfolio_return_percentage_negative_pnl(monkeypatch):
+    """Test return_percentage calculation with negative P&L"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 60000.0,
+        "realized_pnl": -2000.0,  # Realized loss
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 20,
+            "average_price": 2500.0,
+            "current_price": 2400.0,  # Unrealized loss: 20 * (2400 - 2500) = -2000
+        }
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+        mock_ticker_instance = MagicMock()
+        mock_ticker_instance.info = {"currentPrice": 2400.0}
+        mock_ticker_class.return_value = mock_ticker_instance
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Expected: total_pnl = realized_pnl (-2000) + unrealized_pnl (-2000) = -4000
+        # return_percentage = (-4000 / 100000) * 100 = -4.0%
+        expected_total_pnl = -2000.0 + (20 * (2400.0 - 2500.0))  # -4000.0
+        expected_return_pct = (expected_total_pnl / 100000.0) * 100  # -4.0%
+
+        assert result.account.total_pnl == expected_total_pnl
+        assert result.account.return_percentage == pytest.approx(expected_return_pct, rel=1e-6)
+        assert result.account.return_percentage == -4.0
+
+
+def test_get_paper_trading_portfolio_return_percentage_zero_initial_capital(monkeypatch):
+    """Test return_percentage calculation with zero initial capital"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 0.0,  # Zero initial capital
+        "available_cash": 0.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {}
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker"):
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Should return 0.0 when initial_capital is 0
+        assert result.account.return_percentage == 0.0
+
+
+def test_get_paper_trading_portfolio_return_percentage_consistency(monkeypatch):
+    """Test that return_percentage matches total_pnl calculation"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 200000.0,
+        "available_cash": 100000.0,
+        "realized_pnl": 15000.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 10,
+            "average_price": 2500.0,
+            "current_price": 2600.0,  # Unrealized: 10 * 100 = 1000
+        },
+        "TCS.NS": {
+            "quantity": 20,
+            "average_price": 3500.0,
+            "current_price": 3400.0,  # Unrealized: 20 * -100 = -2000
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    call_count = [0]
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+
+        def create_mock_ticker(symbol):
+            call_count[0] += 1
+            mock_ticker = MagicMock()
+            if "RELIANCE" in symbol or call_count[0] <= 1:
+                mock_ticker.info = {"currentPrice": 2600.0}
+            else:
+                mock_ticker.info = {"currentPrice": 3400.0}
+            return mock_ticker
+
+        mock_ticker_class.side_effect = create_mock_ticker
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Calculate expected values
+        # RELIANCE: 10 * (2600 - 2500) = 1000
+        # TCS: 20 * (3400 - 3500) = -2000
+        # Total unrealized: 1000 + (-2000) = -1000
+        # Total P&L: 15000 (realized) + (-1000) (unrealized) = 14000
+        # Return %: (14000 / 200000) * 100 = 7.0%
+
+        expected_unrealized_pnl = (10 * (2600.0 - 2500.0)) + (20 * (3400.0 - 3500.0))  # -1000
+        expected_total_pnl = 15000.0 + expected_unrealized_pnl  # 14000
+        expected_return_pct = (expected_total_pnl / 200000.0) * 100  # 7.0%
+
+        assert result.account.total_pnl == pytest.approx(expected_total_pnl, rel=1e-6)
+        assert result.account.return_percentage == pytest.approx(expected_return_pct, rel=1e-6)
+        # Verify consistency: return_percentage should equal (total_pnl / initial_capital) * 100
+        calculated_return = (result.account.total_pnl / result.account.initial_capital) * 100
+        assert result.account.return_percentage == pytest.approx(calculated_return, rel=1e-6)
+
+
+def test_get_paper_trading_portfolio_portfolio_value_calculation(monkeypatch):
+    """Test portfolio value calculation from holdings"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 50000.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 10,
+            "average_price": 2500.0,
+            "current_price": 2600.0,
+        },
+        "TCS.NS": {
+            "quantity": 20,
+            "average_price": 3500.0,
+            "current_price": 3600.0,
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    call_count = [0]
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+
+        def create_mock_ticker(ticker_symbol):
+            call_count[0] += 1
+            mock_ticker = MagicMock()
+            if "RELIANCE" in ticker_symbol or call_count[0] == 1:
+                mock_ticker.info = {"currentPrice": 2600.0}
+            elif "TCS" in ticker_symbol or call_count[0] == 2:
+                mock_ticker.info = {"currentPrice": 3600.0}
+            else:
+                mock_ticker.info = {}
+            return mock_ticker
+
+        mock_ticker_class.side_effect = create_mock_ticker
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Expected portfolio value: (10 * 2600) + (20 * 3600) = 26000 + 72000 = 98000
+        expected_portfolio_value = (10 * 2600.0) + (20 * 3600.0)  # 98000.0
+        assert result.account.portfolio_value == pytest.approx(expected_portfolio_value, rel=1e-6)
+        assert result.account.portfolio_value == 98000.0
+
+
+def test_get_paper_trading_portfolio_total_value_calculation(monkeypatch):
+    """Test total value calculation (cash + portfolio)"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 30000.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 20,
+            "average_price": 2500.0,
+            "current_price": 2600.0,
+        }
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+        mock_ticker_instance = MagicMock()
+        mock_ticker_instance.info = {"currentPrice": 2600.0}
+        mock_ticker_class.return_value = mock_ticker_instance
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Expected total value: cash (30000) + portfolio (20 * 2600 = 52000) = 82000
+        expected_total_value = 30000.0 + (20 * 2600.0)  # 82000.0
+        assert result.account.total_value == pytest.approx(expected_total_value, rel=1e-6)
+        assert result.account.total_value == 82000.0
+        # Verify: total_value = available_cash + portfolio_value
+        assert result.account.total_value == (
+            result.account.available_cash + result.account.portfolio_value
+        )
+
+
+def test_get_paper_trading_portfolio_unrealized_pnl_calculation(monkeypatch):
+    """Test unrealized P&L calculation for holdings"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 50000.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 10,
+            "average_price": 2500.0,
+            "current_price": 2600.0,  # Profit: 10 * 100 = 1000
+        },
+        "TCS.NS": {
+            "quantity": 20,
+            "average_price": 3500.0,
+            "current_price": 3400.0,  # Loss: 20 * -100 = -2000
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    call_count = [0]
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+
+        def create_mock_ticker(ticker_symbol):
+            call_count[0] += 1
+            mock_ticker = MagicMock()
+            if "RELIANCE" in ticker_symbol or call_count[0] <= 1:
+                mock_ticker.info = {"currentPrice": 2600.0}
+            elif "TCS" in ticker_symbol or call_count[0] == 2:
+                mock_ticker.info = {"currentPrice": 3400.0}
+            else:
+                mock_ticker.info = {}
+            return mock_ticker
+
+        mock_ticker_class.side_effect = create_mock_ticker
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Expected unrealized P&L: (10 * (2600 - 2500)) + (20 * (3400 - 3500)) = 1000 - 2000 = -1000
+        expected_unrealized_pnl = (10 * (2600.0 - 2500.0)) + (20 * (3400.0 - 3500.0))  # -1000.0
+        assert result.account.unrealized_pnl == pytest.approx(expected_unrealized_pnl, rel=1e-6)
+        assert result.account.unrealized_pnl == -1000.0
+
+        # Verify individual holdings P&L
+        reliance_holding = next(h for h in result.holdings if h.symbol == "RELIANCE.NS")
+        tcs_holding = next(h for h in result.holdings if h.symbol == "TCS.NS")
+        assert reliance_holding.pnl == 1000.0  # 10 * (2600 - 2500)
+        assert tcs_holding.pnl == -2000.0  # 20 * (3400 - 3500)
+
+
+def test_get_paper_trading_portfolio_holding_pnl_percentage_calculation(monkeypatch):
+    """Test individual holding P&L percentage calculation"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 50000.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 10,
+            "average_price": 2500.0,
+            "current_price": 2750.0,  # 10% gain: (2750 - 2500) / 2500 * 100 = 10%
+        },
+        "TCS.NS": {
+            "quantity": 20,
+            "average_price": 3500.0,
+            "current_price": 3150.0,  # 10% loss: (3150 - 3500) / 3500 * 100 = -10%
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    call_count = [0]
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+
+        def create_mock_ticker(ticker_symbol):
+            call_count[0] += 1
+            mock_ticker = MagicMock()
+            if "RELIANCE" in ticker_symbol or call_count[0] <= 1:
+                mock_ticker.info = {"currentPrice": 2750.0}
+            elif "TCS" in ticker_symbol or call_count[0] == 2:
+                mock_ticker.info = {"currentPrice": 3150.0}
+            else:
+                mock_ticker.info = {}
+            return mock_ticker
+
+        mock_ticker_class.side_effect = create_mock_ticker
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Verify P&L percentage for each holding
+        reliance_holding = next(h for h in result.holdings if h.symbol == "RELIANCE.NS")
+        tcs_holding = next(h for h in result.holdings if h.symbol == "TCS.NS")
+
+        # RELIANCE: (2750 - 2500) / 2500 * 100 = 10%
+        expected_reliance_pnl_pct = ((2750.0 - 2500.0) / 2500.0) * 100
+        assert reliance_holding.pnl_percentage == pytest.approx(expected_reliance_pnl_pct, rel=1e-6)
+        assert reliance_holding.pnl_percentage == 10.0
+
+        # TCS: (3150 - 3500) / 3500 * 100 = -10%
+        expected_tcs_pnl_pct = ((3150.0 - 3500.0) / 3500.0) * 100
+        assert tcs_holding.pnl_percentage == pytest.approx(expected_tcs_pnl_pct, rel=1e-6)
+        assert tcs_holding.pnl_percentage == -10.0
+
+
+def test_get_paper_trading_portfolio_cost_basis_calculation(monkeypatch):
+    """Test cost basis calculation for holdings"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 50000.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 15,
+            "average_price": 2500.0,
+            "current_price": 2600.0,
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+        mock_ticker_instance = MagicMock()
+        mock_ticker_instance.info = {"currentPrice": 2600.0}
+        mock_ticker_class.return_value = mock_ticker_instance
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        holding = result.holdings[0]
+        # Cost basis = quantity * average_price = 15 * 2500 = 37500
+        expected_cost_basis = 15 * 2500.0  # 37500.0
+        assert holding.cost_basis == pytest.approx(expected_cost_basis, rel=1e-6)
+        assert holding.cost_basis == 37500.0
+
+
+def test_get_paper_trading_portfolio_market_value_calculation(monkeypatch):
+    """Test market value calculation for holdings"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 50000.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 20,
+            "average_price": 2500.0,
+            "current_price": 2600.0,
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+        mock_ticker_instance = MagicMock()
+        mock_ticker_instance.info = {"currentPrice": 2600.0}
+        mock_ticker_class.return_value = mock_ticker_instance
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        holding = result.holdings[0]
+        # Market value = quantity * current_price = 20 * 2600 = 52000
+        expected_market_value = 20 * 2600.0  # 52000.0
+        assert holding.market_value == pytest.approx(expected_market_value, rel=1e-6)
+        assert holding.market_value == 52000.0
+
+
+def test_get_paper_trading_portfolio_total_pnl_consistency(monkeypatch):
+    """Test that total_pnl = realized_pnl + unrealized_pnl"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 40000.0,
+        "realized_pnl": 5000.0,  # Realized profit
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 20,
+            "average_price": 2500.0,
+            "current_price": 2600.0,  # Unrealized: 20 * 100 = 2000
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+        mock_ticker_instance = MagicMock()
+        mock_ticker_instance.info = {"currentPrice": 2600.0}
+        mock_ticker_class.return_value = mock_ticker_instance
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # Verify: total_pnl = realized_pnl + unrealized_pnl
+        expected_total_pnl = result.account.realized_pnl + result.account.unrealized_pnl
+        assert result.account.total_pnl == pytest.approx(expected_total_pnl, rel=1e-6)
+        # Expected: 5000 (realized) + 2000 (unrealized) = 7000
+        assert result.account.total_pnl == 7000.0
+
+
+def test_get_paper_trading_portfolio_zero_quantity_holding(monkeypatch):
+    """Test handling of holdings with zero quantity"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 50000.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 0,  # Zero quantity
+            "average_price": 2500.0,
+            "current_price": 2600.0,
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+        mock_ticker_instance = MagicMock()
+        mock_ticker_instance.info = {"currentPrice": 2600.0}
+        mock_ticker_class.return_value = mock_ticker_instance
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        # With zero quantity, all values should be zero
+        holding = result.holdings[0]
+        assert holding.cost_basis == 0.0
+        assert holding.market_value == 0.0
+        assert holding.pnl == 0.0
+        assert holding.pnl_percentage == 0.0
+        assert result.account.portfolio_value == 0.0
+
+
+def test_get_paper_trading_portfolio_zero_average_price(monkeypatch):
+    """Test handling of holdings with zero average price"""
+    user = DummyUser(id=42)
+
+    def mock_exists(self):
+        return True
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    store = DummyPaperTradeStore("test_path")
+    store._account = {
+        "initial_capital": 100000.0,
+        "available_cash": 50000.0,
+        "realized_pnl": 0.0,
+    }
+    store._holdings = {
+        "RELIANCE.NS": {
+            "quantity": 10,
+            "average_price": 0.0,  # Zero average price
+            "current_price": 2600.0,
+        },
+    }
+    store._orders = []
+
+    def mock_store_init(storage_path, auto_save=False):
+        return store
+
+    monkeypatch.setattr(paper_trading, "PaperTradeStore", mock_store_init)
+
+    def mock_reporter_init(store):
+        return DummyPaperTradeReporter(store)
+
+    monkeypatch.setattr(paper_trading, "PaperTradeReporter", mock_reporter_init)
+
+    with patch("yfinance.Ticker") as mock_ticker_class:
+        mock_ticker_instance = MagicMock()
+        mock_ticker_instance.info = {"currentPrice": 2600.0}
+        mock_ticker_class.return_value = mock_ticker_instance
+
+        def mock_path_exists(self):
+            return False if "active_sell_orders.json" in str(self) else True
+
+        monkeypatch.setattr(Path, "exists", mock_path_exists)
+
+        result = paper_trading.get_paper_trading_portfolio(db=None, current=user)
+
+        holding = result.holdings[0]
+        # Cost basis should be 0 (10 * 0)
+        assert holding.cost_basis == 0.0
+        # Market value should be 26000 (10 * 2600)
+        assert holding.market_value == 26000.0
+        # P&L should be 26000 (market_value - cost_basis)
+        assert holding.pnl == 26000.0
+        # P&L percentage should be 0 (division by zero protection)
+        assert holding.pnl_percentage == 0.0


### PR DESCRIPTION
- Calculate return_percentage based on total_pnl instead of total_value - initial_capital
- Ensures consistency between displayed total_pnl and return_percentage
- Fix bug: P&L percentage for zero quantity holdings now returns 0% instead of price-based percentage
- Add comprehensive test cases for all portfolio calculations:
  * Return percentage (positive, negative, zero initial capital, consistency)
  * Portfolio value calculation
  * Total value calculation (cash + portfolio)
  * Unrealized P&L calculation
  * Individual holding P&L and P&L percentage
  * Cost basis and market value calculations
  * Total P&L consistency (realized + unrealized)
  * Edge cases (zero quantity, zero average price)

Fixes issue where return percentage didn't match displayed total P&L