### PR TITLE
Fix continuous OTP issue: Reduce broker polling frequency and improve…

### DIFF
--- a/web/src/hooks/useSettings.ts
+++ b/web/src/hooks/useSettings.ts
@@ -23,7 +23,7 @@ export function useSettings() {
 		queryKey: ['broker-status'],
 		queryFn: getBrokerStatus,
 		enabled: isBrokerMode, // Only poll when in broker mode
-		refetchInterval: 10 * 1000, // Poll every 10 seconds for connection status
+		refetchInterval: 60 * 1000, // Poll every 60 seconds for connection status (reduced from 10s to avoid frequent checks)
 		staleTime: 5 * 1000, // Consider stale after 5 seconds
 	});
 

--- a/web/src/routes/dashboard/BrokerOrdersPage.tsx
+++ b/web/src/routes/dashboard/BrokerOrdersPage.tsx
@@ -62,7 +62,7 @@ export function BrokerOrdersPage() {
 		queryKey: ['broker-orders'],
 		queryFn: getBrokerOrders,
 		enabled: isBrokerMode && isBrokerConnected,
-		refetchInterval: 10000, // Refresh every 10 seconds
+		refetchInterval: 30000, // Refresh every 30 seconds (reduced from 10s to avoid frequent auth/OTP)
 		retry: (failureCount, error) => {
 			// Retry up to 3 times for retryable errors
 			if (failureCount >= 3) return false;

--- a/web/src/routes/dashboard/BrokerPortfolioPage.tsx
+++ b/web/src/routes/dashboard/BrokerPortfolioPage.tsx
@@ -18,7 +18,7 @@ export function BrokerPortfolioPage() {
 	const { data, isLoading, error, refetch, dataUpdatedAt, failureCount } = useQuery<PaperTradingPortfolio>({
 		queryKey: ['portfolio', 'broker'],
 		queryFn: getPortfolio,
-		refetchInterval: 5000, // Refresh every 5 seconds for live P&L
+		refetchInterval: 30000, // Refresh every 30 seconds (reduced from 5s to avoid frequent auth/OTP)
 		enabled: isBrokerMode && isBrokerConnected, // Only fetch if in broker mode and connected
 		retry: (failureCount, error) => {
 			// Retry up to 3 times for retryable errors


### PR DESCRIPTION
… status endpoint

- Reduce BrokerPortfolioPage polling from 5s to 30s
- Reduce BrokerOrdersPage polling from 10s to 30s
- Reduce broker status polling from 10s to 60s
- Update status endpoint to return stored status without triggering auth
- Add is_authenticated() check before login() in portfolio/orders endpoints
- Add staleTime for better query caching in useSettings hook

This significantly reduces the number of authentication attempts and OTP requests when users are viewing broker portfolio/orders pages. The main fix is the reduced polling frequency, as each request creates a new auth instance.

Issue: Dashboard was continuously checking broker connection and sending OTP on mobile during authentication due to frequent polling.