### PR TITLE
Fix: Skip broker.connect() if auth already authenticated to prevent O…

### DIFF
--- a/server/app/routers/broker.py
+++ b/server/app/routers/broker.py
@@ -563,11 +563,20 @@ def get_broker_portfolio(  # noqa: PLR0915, PLR0912, B008
             # Create broker gateway
             broker = BrokerFactory.create_broker("kotak_neo", auth_handler=auth)
 
-            # Connect to broker
-            if not broker.connect():
-                raise HTTPException(
-                    status_code=503,
-                    detail="Failed to connect to broker gateway. Please try again later.",
+            # Connect to broker (only if not already connected)
+            # broker.connect() calls auth.login() which triggers OTP,
+            # so skip if already authenticated
+            if not auth.is_authenticated():
+                if not broker.connect():
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Failed to connect to broker gateway. Please try again later.",
+                    )
+            else:
+                # Auth is already authenticated, just ensure broker is initialized
+                # The broker gateway should work with the existing auth session
+                logger.debug(
+                    f"Auth already authenticated for user {current.id}, skipping connect()"
                 )
 
             # Get holdings from broker
@@ -801,11 +810,20 @@ def get_broker_orders(  # noqa: PLR0915, PLR0912, B008
             # Create broker gateway
             broker_gateway = BrokerFactory.create_broker("kotak_neo", auth_handler=auth)
 
-            # Connect to broker
-            if not broker_gateway.connect():
-                raise HTTPException(
-                    status_code=503,
-                    detail="Failed to connect to broker gateway. Please try again later.",
+            # Connect to broker (only if not already connected)
+            # broker.connect() calls auth.login() which triggers OTP,
+            # so skip if already authenticated
+            if not auth.is_authenticated():
+                if not broker_gateway.connect():
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Failed to connect to broker gateway. Please try again later.",
+                    )
+            else:
+                # Auth is already authenticated, just ensure broker is initialized
+                # The broker gateway should work with the existing auth session
+                logger.debug(
+                    f"Auth already authenticated for user {current.id}, skipping connect()"
                 )
 
             # Get orders from broker


### PR DESCRIPTION
…TP spam

- broker.connect() calls auth.login() which triggers OTP every time
- Check if auth.is_authenticated() before calling broker.connect()
- Skip connect() call if auth is already authenticated (reusing cached session)
- Prevents OTP requests on every API call when session is cached