### PR TITLE
Fix: Update holdings parser to use Kotak Neo API response format

### DIFF
--- a/server/app/routers/broker.py
+++ b/server/app/routers/broker.py
@@ -587,17 +587,18 @@ def get_broker_portfolio(  # noqa: PLR0915, PLR0912, B008
             # Get account limits/margins for available cash
             try:
                 account_limits = broker.get_account_limits()
-                # Extract available cash from account limits
-                # Structure may vary by broker, adjust as needed
-                available_cash = float(
-                    account_limits.get("available_margin", {}).get("cash", 0.0)
-                    or account_limits.get("cash", 0.0)
-                    or 0.0
+                # Extract available cash from account limits (returns Money objects)
+                available_cash_money = account_limits.get("available_cash") or account_limits.get(
+                    "net"
                 )
-            except Exception:
+                if available_cash_money and hasattr(available_cash_money, "amount"):
+                    available_cash = float(available_cash_money.amount)
+                else:
+                    available_cash = 0.0
+            except Exception as e:
                 # If account limits not available, set to 0
                 available_cash = 0.0
-                logger.warning("Could not fetch account limits for broker portfolio")
+                logger.warning(f"Could not fetch account limits for broker portfolio: {e}")
 
             # Convert broker holdings to paper trading format
             portfolio_holdings = []


### PR DESCRIPTION
- Prioritize displaySymbol, averagePrice, closingPrice fields (Kotak API format)
- Add fallback to calculate current_price from mktValue when closingPrice is 0
- Improve field name handling with proper priority order
- Add comprehensive test suite for holdings parsing

Changes:
- Symbol: displaySymbol (primary) > symbol > tradingSymbol (fallback)
- Average price: averagePrice (primary) > avgPrice (fallback)
- Current price: closingPrice (primary) > ltp > mktValue calculation (fallback)
- Skip holdings with empty symbols
- Handle error cases gracefully

Tests:
- Test exact Kotak Neo API response format
- Test field name fallbacks and backward compatibility
- Test error handling and edge cases
- Test get_holding() for specific symbols

Fixes holdings parsing to match Kotak Neo API response structure