### PR TITLE
fix(security): address CodeQL logging and command-injection findings

### DIFF
--- a/modules/kotak_neo_auto_trader/auth.py
+++ b/modules/kotak_neo_auto_trader/auth.py
@@ -143,31 +143,31 @@ class KotakNeoAuth:
             ]
             raise ValueError(f"Missing credentials: {', '.join(missing)}")
 
-        # Log masked fingerprint for debugging credential source mismatches
+        # Log only non-sensitive metadata (CodeQL: no partial secrets or PII in logs)
         self.logger.info(
-            "Kotak credential fingerprint loaded: "
-            f"{self._credentials_fingerprint()} from config_file={self.config_file}"
+            "Kotak credentials loaded: %s (config=%s)",
+            self._credentials_fingerprint(),
+            self._config_file_basename(),
         )
 
+    def _config_file_basename(self) -> str:
+        if not self.config_file:
+            return "none"
+        from os.path import basename
+
+        return basename(str(self.config_file))
+
     def _credentials_fingerprint(self) -> str:
-        """Return masked credential fingerprint (no secret leakage)."""
+        """Return non-sensitive credential presence metadata for troubleshooting."""
 
-        def _tail(value: str, n: int = 4) -> str:
-            v = (value or "").strip()
-            if not v:
-                return "none"
-            return f"...{v[-n:]}" if len(v) >= n else v
-
-        mobile = (self.mobile_number or "").strip()
-        mobile_mask = f"...{mobile[-3:]}" if len(mobile) >= 3 else (mobile or "none")
-        env = (self.environment or "prod").strip()
+        env = (self.environment or "prod").strip() or "prod"
         return (
-            f"key={_tail(self.consumer_key, 6)}, "
-            f"ucc={_tail(self.consumer_secret, 4)}, "
-            f"mobile={mobile_mask}, "
-            f"mpin_len={len((self.mpin or '').strip())}, "
-            f"totp_len={len((self.totp_secret or '').strip())}, "
-            f"env={env}"
+            f"env={env}, "
+            f"has_api_key={bool((self.consumer_key or '').strip())}, "
+            f"has_ucc={bool((self.consumer_secret or '').strip())}, "
+            f"has_mobile={bool((self.mobile_number or '').strip())}, "
+            f"has_mpin={bool((self.mpin or '').strip())}, "
+            f"has_totp={bool((self.totp_secret or '').strip())}"
         )
 
     def _perform_rest_login(self) -> bool:
@@ -352,9 +352,12 @@ class KotakNeoAuth:
 
         try:
             self.logger.info("Starting Kotak Neo API login process...")
-            self.logger.info(f"Mobile: {self.mobile_number}")
+            self.logger.info(
+                "Mobile present: %s",
+                bool((self.mobile_number or "").strip()),
+            )
             self.logger.info(f"Environment: {self.environment}")
-            self.logger.info(f"Login fingerprint: {self._credentials_fingerprint()}")
+            self.logger.info("Login credential metadata: %s", self._credentials_fingerprint())
 
             # Suppress output during entire login process
             with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):

--- a/server/app/routers/broker.py
+++ b/server/app/routers/broker.py
@@ -100,23 +100,16 @@ class KotakNeoCreds:
 
 
 def _masked_creds_fingerprint(creds: KotakNeoCreds) -> str:
-    """Return masked broker credential fingerprint for troubleshooting."""
+    """Return non-sensitive broker credential metadata for troubleshooting (no secret tails)."""
 
-    def _tail(value: str | None, n: int = 4) -> str:
-        v = (value or "").strip()
-        if not v:
-            return "none"
-        return f"...{v[-n:]}" if len(v) >= n else v
-
-    mobile = (creds.mobile_number or "").strip()
-    mobile_mask = f"...{mobile[-3:]}" if len(mobile) >= 3 else (mobile or "none")
+    env = (creds.environment or "prod").strip() or "prod"
     return (
-        f"key={_tail(creds.consumer_key, 6)}, "
-        f"ucc={_tail(creds.consumer_secret, 4)}, "
-        f"mobile={mobile_mask}, "
-        f"mpin_len={len((creds.mpin or '').strip())}, "
-        f"totp_len={len((creds.totp_secret or '').strip())}, "
-        f"env={(creds.environment or 'prod').strip()}"
+        f"env={env}, "
+        f"has_key={bool((creds.consumer_key or '').strip())}, "
+        f"has_secret={bool((creds.consumer_secret or '').strip())}, "
+        f"has_mobile={bool((creds.mobile_number or '').strip())}, "
+        f"has_mpin={bool((creds.mpin or '').strip())}, "
+        f"has_totp={bool((creds.totp_secret or '').strip())}"
     )
 
 

--- a/server/app/routers/notification_preferences.py
+++ b/server/app/routers/notification_preferences.py
@@ -1,3 +1,4 @@
+# ruff: noqa: B008
 """
 Notification Preferences API Router
 
@@ -25,55 +26,62 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-def _test_telegram_connection(bot_token: str, chat_id: str) -> tuple[bool, str]:
+def _test_telegram_connection(bot_token: str, chat_id: str) -> tuple[bool, str]:  # noqa: PLR0911
     """
     Test Telegram bot connection by sending a test message.
-    
+
     Args:
         bot_token: Telegram bot token
         chat_id: Telegram chat ID
-        
+
     Returns:
         tuple[bool, str]: (success, message)
     """
     try:
-        import requests
-        
+        import requests  # noqa: PLC0415  # lazy: tests inject fake `requests` via sys.modules
+
         # Validate inputs
         if not bot_token or not chat_id:
             return False, "Bot token and chat ID are required"
-        
+
         # Test by sending a message
         url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
         payload = {
             "chat_id": chat_id,
             "text": "✅ Telegram connection test successful!\n\nYour bot is configured correctly.",
-            "parse_mode": "HTML"
+            "parse_mode": "HTML",
         }
-        
+
         response = requests.post(url, json=payload, timeout=10)
-        
-        if response.status_code == 200:
+
+        if response.status_code == status.HTTP_200_OK:
             return True, "Test message sent successfully! Check your Telegram chat."
         else:
             error_data = response.json()
             error_desc = error_data.get("description", "Unknown error")
-            
+
             # Provide helpful error messages
             if "bot token" in error_desc.lower() or "unauthorized" in error_desc.lower():
-                return False, f"Invalid bot token. Please check your token. Error: {error_desc}"
-            elif "chat not found" in error_desc.lower():
-                return False, f"Invalid chat ID. Make sure you've started a chat with the bot. Error: {error_desc}"
-            else:
-                return False, f"Telegram API error: {error_desc}"
-                
+                return (
+                    False,
+                    f"Invalid bot token. Please check your token. Error: {error_desc}",
+                )
+            if "chat not found" in error_desc.lower():
+                return (
+                    False,
+                    "Invalid chat ID. Make sure you've started a chat with the bot. "
+                    f"Error: {error_desc}",
+                )
+            return False, f"Telegram API error: {error_desc}"
+
     except requests.exceptions.Timeout:
         return False, "Connection timeout. Please check your internet connection."
     except requests.exceptions.RequestException as e:
-        return False, f"Network error: {str(e)}"
+        logger.warning("Telegram test request error: %s", e, exc_info=True)
+        return False, "Network error while contacting Telegram. Please check your connection."
     except Exception as e:
-        logger.error(f"Telegram test error: {e}", exc_info=True)
-        return False, f"Test failed: {str(e)}"
+        logger.error("Telegram test error: %s", e, exc_info=True)
+        return False, "Unable to complete the connection test. Please try again later."
 
 
 def _preferences_to_response(prefs: UserNotificationPreferences) -> NotificationPreferencesResponse:
@@ -185,11 +193,11 @@ def test_telegram_connection(
 ) -> dict[str, Any]:
     """
     Test Telegram bot connection by sending a test message.
-    
+
     Args:
         bot_token: Telegram bot token
         chat_id: Telegram chat ID
-        
+
     Returns:
         {"success": bool, "message": str}
     """
@@ -197,8 +205,8 @@ def test_telegram_connection(
         success, message = _test_telegram_connection(bot_token, chat_id)
         return {"success": success, "message": message}
     except Exception as e:
-        logger.exception(f"Error testing Telegram connection for user {current_user.id}: {e}")
+        logger.exception("Error testing Telegram connection for user %s", current_user.id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to test Telegram connection: {str(e)}",
+            detail="Failed to test Telegram connection.",
         ) from e

--- a/web/tests/e2e/DATABASE.md
+++ b/web/tests/e2e/DATABASE.md
@@ -47,6 +47,15 @@ The tests make HTTP requests to the API server. The API server reads/writes to i
 | `E2E_DB_URL` | Database URL for E2E tests/seeding | `sqlite:///./data/e2e.db` |
 | `E2E_SEED_DATA` | Enable automatic seeding in global-setup | `false` |
 
+### Seeding (`global-setup.ts`) constraints
+
+When `E2E_SEED_DATA` is enabled, the seed script is invoked with **`execFileSync` (no shell)** for safety. That imposes:
+
+- **`E2E_DB_URL`** must start with **`sqlite:`** or **`file:`** (case-insensitive). Other schemes (e.g. `postgresql://`) are rejected. The value must not contain shell metacharacters such as `` ` ``, `$`, `;`, or newlines.
+- **`E2E_SEED_SIGNALS`**, **`E2E_SEED_ORDERS`**, **`E2E_SEED_NOTIFICATIONS`** must be non-negative integers as digit strings (defaults: `5`, `3`, `5`; max `100000`).
+
+Use a normal SQLite file or in-memory-style URL under `sqlite:` / `file:` as in the defaults above.
+
 ### Test Runner Scripts (Recommended)
 
 The test runner scripts automatically configure the correct database:

--- a/web/tests/e2e/global-setup.ts
+++ b/web/tests/e2e/global-setup.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { FullConfig } from '@playwright/test';
 import { TestConfig } from './config/test-config';
@@ -57,28 +57,45 @@ async function globalSetup(_config: FullConfig) {
 			// From web/tests/e2e/global-setup.ts to web/tests/e2e/utils/seed-db.py
 			const projectRoot = process.cwd();
 			const scriptPath = join(projectRoot, 'web', 'tests', 'e2e', 'utils', 'seed-db.py');
-			const signalsCount = process.env.E2E_SEED_SIGNALS || '5';
-			const ordersCount = process.env.E2E_SEED_ORDERS || '3';
-			const notificationsCount = process.env.E2E_SEED_NOTIFICATIONS || '5';
-			const dbUrl = process.env.E2E_DB_URL || 'sqlite:///./data/e2e.db';
 
-			// Execute Python seeding script
-			// Change to project root directory for relative path resolution
-			const command = [
-				'python',
-				scriptPath.replace(/\\/g, '/'), // Normalize path separators
-				'--signals', signalsCount,
-				'--orders', ordersCount,
-				'--notifications', notificationsCount,
-				'--db-url', dbUrl,
+			const parseSeedCount = (raw: string | undefined, fallback: string): string => {
+				const v = (raw ?? fallback).trim();
+				if (!/^\d+$/.test(v)) {
+					throw new Error(`Invalid seed count (expected digits): ${v}`);
+				}
+				const n = Number(v);
+				if (n < 0 || n > 100_000) {
+					throw new Error(`Invalid seed count (out of range): ${v}`);
+				}
+				return v;
+			};
+
+			const signalsCount = parseSeedCount(process.env.E2E_SEED_SIGNALS, '5');
+			const ordersCount = parseSeedCount(process.env.E2E_SEED_ORDERS, '3');
+			const notificationsCount = parseSeedCount(process.env.E2E_SEED_NOTIFICATIONS, '5');
+			const dbUrl = (process.env.E2E_DB_URL || 'sqlite:///./data/e2e.db').trim();
+			if (!/^(sqlite:|file:)/i.test(dbUrl) || /[\r\n;&|`$]/.test(dbUrl)) {
+				throw new Error('Invalid E2E_DB_URL for seed script (allowed: sqlite:/ or file: URLs only)');
+			}
+
+			const args = [
+				scriptPath,
+				'--signals',
+				signalsCount,
+				'--orders',
+				ordersCount,
+				'--notifications',
+				notificationsCount,
+				'--db-url',
+				dbUrl,
 				...(process.env.E2E_CLEAR_BEFORE_SEED === 'true' ? ['--clear'] : []),
-			].join(' ');
+			];
 
-			execSync(command, {
-				cwd: projectRoot, // Run from project root
+			// argv array + no shell avoids command-injection findings on env-derived strings
+			execFileSync('python', args, {
+				cwd: projectRoot,
 				stdio: 'inherit',
 				encoding: 'utf-8',
-				shell: true, // Use shell for better cross-platform support
 			});
 
 			console.log('✓ Test data seeded successfully');


### PR DESCRIPTION
Use non-sensitive credential metadata in Kotak auth and broker logs; avoid client-facing exception strings for Telegram test; run E2E seed via execFileSync with validated argv and document E2E_DB_URL constraints.

Made-with: Cursor